### PR TITLE
fix: use relative paths for referencing fonts

### DIFF
--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -4,8 +4,8 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url("/fonts/BundesSansWeb-Regular.woff2") format("woff2"),
-    url("/fonts/BundesSansWeb-Regular.woff") format("woff");
+  src: url("./fonts/BundesSansWeb-Regular.woff2") format("woff2"),
+    url("./fonts/BundesSansWeb-Regular.woff") format("woff");
 }
 
 @font-face {
@@ -13,8 +13,8 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url("/fonts/BundesSansWeb-Italic.woff2") format("woff2"),
-    url("/fonts/BundesSansWeb-Italic.woff") format("woff");
+  src: url("./fonts/BundesSansWeb-Italic.woff2") format("woff2"),
+    url("./fonts/BundesSansWeb-Italic.woff") format("woff");
 }
 
 @font-face {
@@ -22,8 +22,8 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url("/fonts/BundesSansWeb-Bold.woff2") format("woff2"),
-    url("/fonts/BundesSansWeb-Bold.woff") format("woff");
+  src: url("./fonts/BundesSansWeb-Bold.woff2") format("woff2"),
+    url("./fonts/BundesSansWeb-Bold.woff") format("woff");
 }
 
 @font-face {
@@ -31,8 +31,8 @@
   font-style: italic;
   font-weight: 700;
   font-display: swap;
-  src: url("/fonts/BundesSansWeb-BoldItalic.woff2") format("woff2"),
-    url("/fonts/BundesSansWeb-BoldItalic.woff") format("woff");
+  src: url("./fonts/BundesSansWeb-BoldItalic.woff2") format("woff2"),
+    url("./fonts/BundesSansWeb-BoldItalic.woff") format("woff");
 }
 
 /* BundesSerif */
@@ -41,8 +41,8 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url("/fonts/BundesSerifWeb-Regular.woff2") format("woff2"),
-    url("/fonts/BundesSerifWeb-Regular.woff") format("woff");
+  src: url("./fonts/BundesSerifWeb-Regular.woff2") format("woff2"),
+    url("./fonts/BundesSerifWeb-Regular.woff") format("woff");
 }
 
 @font-face {
@@ -50,8 +50,8 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url("/fonts/BundesSerifWeb-Italic.woff2") format("woff2"),
-    url("/fonts/BundesSerifWeb-Italic.woff") format("woff");
+  src: url("./fonts/BundesSerifWeb-Italic.woff2") format("woff2"),
+    url("./fonts/BundesSerifWeb-Italic.woff") format("woff");
 }
 
 @font-face {
@@ -59,8 +59,8 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url("/fonts/BundesSerifWeb-Bold.woff2") format("woff2"),
-    url("/fonts/BundesSerifWeb-Bold.woff") format("woff");
+  src: url("./fonts/BundesSerifWeb-Bold.woff2") format("woff2"),
+    url("./fonts/BundesSerifWeb-Bold.woff") format("woff");
 }
 
 @font-face {
@@ -68,8 +68,8 @@
   font-style: italic;
   font-weight: 700;
   font-display: swap;
-  src: url("/fonts/BundesSerifWeb-BoldItalic.woff2") format("woff2"),
-    url("/fonts/BundesSerifWeb-BoldItalic.woff") format("woff");
+  src: url("./fonts/BundesSerifWeb-BoldItalic.woff2") format("woff2"),
+    url("./fonts/BundesSerifWeb-BoldItalic.woff") format("woff");
 }
 
 /* BundesSans Condensed */
@@ -78,6 +78,6 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url("/fonts/BundesSansCondWeb.woff2") format("woff2"),
-    url("/fonts/BundesSansCondWeb.woff") format("woff");
+  src: url("./fonts/BundesSansCondWeb.woff2") format("woff2"),
+    url("./fonts/BundesSansCondWeb.woff") format("woff");
 }


### PR DESCRIPTION
This is needed for using the fonts included in the distributable of this repository in projects where angie is included as a dependency. With absolute paths, bundlers will try to find the font in the project itself (which will then fail), instead of taking them from the installed package.