### PR TITLE
fix(checkbox): use styled inputs instead of pseudo-elements

### DIFF
--- a/docs/pages/components/checkbox.md
+++ b/docs/pages/components/checkbox.md
@@ -33,6 +33,25 @@ layout: layouts/sidebar.njk
 <label for="c3">Lorem ipsum</label>
 ```
 
+#### with multiple lines
+
+If the label text is too long to fit on one line, wrap the checkbox and label in a container (e.g. a `div` or a `span`) containing nothing else. This will prevent the label text from wrapping under the checkbox.
+
+```
+<div>
+  <input type="checkbox" value="yes" id="c3" class="ds-checkbox" />
+  <label for="c3">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tincidunt
+    cursus mi, a dictum magna venenatis vitae. Nunc a sollicitudin libero. In
+    a risus iaculis felis eleifend sodales. Morbi ullamcorper congue viverra.
+    Aliquam ullamcorper, neque ac rutrum hendrerit, erat mauris euismod quam,
+    at aliquam diam mauris et magna.
+  </label>
+</div>
+```
+
+Note that this uses the `has` selector, which is only available on recent versions of Chrome and Safari for now. If you need to support Firefox or older browsers, add the `flex` class to the wrapping container instead.
+
 ### Regular size (default)
 
 <div class="ds-stack-24">
@@ -41,7 +60,7 @@ layout: layouts/sidebar.njk
     <label for="c0">Lorem ipsum 1</label>
   </div>
 
-  <div>
+  <div class="flex">
     <input type="checkbox" value="yes" id="c1" class="ds-checkbox" />
     <label for="c1">
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tincidunt
@@ -76,7 +95,7 @@ layout: layouts/sidebar.njk
     <label for="sc0">Lorem ipsum 1</label>
   </div>
 
-  <div>
+  <div class="flex">
     <input type="checkbox" value="yes" id="sc1" class="ds-checkbox ds-checkbox-small" />
     <label for="sc1">
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tincidunt

--- a/docs/pages/components/radio.md
+++ b/docs/pages/components/radio.md
@@ -33,6 +33,25 @@ layout: layouts/sidebar.njk
 <label for="r1">Lorem ipsum</label>
 ```
 
+#### with multiple lines
+
+If the label text is too long to fit on one line, wrap the radio and label in a container (e.g. a `div` or a `span`) containing nothing else. This will prevent the label text from wrapping under the radio.
+
+```
+<div>
+  <input type="radio" name="radios" value="4" id="r3" class="ds-radio" />
+  <label for="r3">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tincidunt
+    cursus mi, a dictum magna venenatis vitae. Nunc a sollicitudin libero. In
+    a risus iaculis felis eleifend sodales. Morbi ullamcorper congue viverra.
+    Aliquam ullamcorper, neque ac rutrum hendrerit, erat mauris euismod quam,
+    at aliquam diam mauris et magna.
+  </label>
+</div>
+```
+
+Note that this uses the `has` selector, which is only available on recent versions of Chrome and Safari for now. If you need to support Firefox or older browsers, add the `flex` class to the wrapping container instead.
+
 ### Regular size (default)
 
 <div class="ds-stack-24">
@@ -46,7 +65,7 @@ layout: layouts/sidebar.njk
     <label for="r1">Lorem ipsum 2</label>
   </div>
 
-  <div>
+  <div class="flex">
     <input type="radio" name="radios" value="4" id="r3" class="ds-radio" />
     <label for="r3">
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tincidunt
@@ -76,7 +95,7 @@ layout: layouts/sidebar.njk
     <label for="sr1">Lorem ipsum 2</label>
   </div>
 
-  <div>
+  <div class="flex">
     <input type="radio" name="sradios" value="4" id="sr3" class="ds-radio ds-radio-small" />
     <label for="sr3">
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tincidunt
@@ -106,7 +125,7 @@ layout: layouts/sidebar.njk
     <label for="mr1">Lorem ipsum 2</label>
   </div>
 
-  <div>
+  <div class="flex">
     <input type="radio" name="mradios" value="4" id="mr3" class="ds-radio ds-radio-mini" />
     <label for="mr3">
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tincidunt

--- a/src/components/checkbox.js
+++ b/src/components/checkbox.js
@@ -1,42 +1,45 @@
-const a11y = require("../utils/a11y");
-
 module.exports = function ({ addComponents, theme }) {
   addComponents({
-    ".ds-checkbox": a11y.srOnly,
+    ".ds-checkbox": {
+      appearance: "none",
+      width: "2.5rem",
+      height: "2.5rem",
+      boxShadow: `inset 0 0 0 0.125rem ${theme("colors.blue.800")}`,
+      position: "relative",
+      outline: "none",
+      cursor: "pointer",
+      float: "left",
+      flex: "none",
+    },
     ".ds-checkbox + label": {
       position: "relative",
-      display: "inline-block",
       paddingTop: "0.4375rem",
-      paddingLeft: "3rem",
+      paddingLeft: "0.5rem",
       minHeight: "2.5rem",
       touchAction: "manipulation",
       cursor: "pointer",
+      verticalAlign: "top",
+      float: "left",
     },
-    ".ds-checkbox + label::before, .ds-checkbox + label::after": {
+    ".ds-checkbox::after": {
       content: '""',
       display: "block",
       position: "absolute",
       top: "0",
     },
-    ".ds-checkbox + label::before": {
-      left: "0",
-      width: "2.5rem",
-      height: "2.5rem",
+    ".ds-checkbox:not(.has-error):focus": {
+      boxShadow: `inset 0 0 0 0.25rem ${theme("colors.blue.800")}`,
+    },
+    ".ds-checkbox:not(.has-error):not(:focus-visible):focus": {
       boxShadow: `inset 0 0 0 0.125rem ${theme("colors.blue.800")}`,
     },
-    ".ds-checkbox:not(.has-error):focus + label::before": {
+    ".ds-checkbox:focus-visible": {
       boxShadow: `inset 0 0 0 0.25rem ${theme("colors.blue.800")}`,
     },
-    ".ds-checkbox:not(.has-error):not(:focus-visible):focus + label::before": {
-      boxShadow: `inset 0 0 0 0.125rem ${theme("colors.blue.800")}`,
-    },
-    ".ds-checkbox:focus-visible + label::before": {
+    ".ds-checkbox:not(:disabled):hover": {
       boxShadow: `inset 0 0 0 0.25rem ${theme("colors.blue.800")}`,
     },
-    ".ds-checkbox:not(:disabled):hover + label::before": {
-      boxShadow: `inset 0 0 0 0.25rem ${theme("colors.blue.800")}`,
-    },
-    ".ds-checkbox:checked + label::after": {
+    ".ds-checkbox:checked::after": {
       top: "1.25rem",
       left: "1.125rem",
       width: "1.0625rem",
@@ -46,27 +49,33 @@ module.exports = function ({ addComponents, theme }) {
       borderWidth: "0 0 0.125rem 0.125rem",
       borderColor: theme("colors.blue.800"),
     },
-    ".ds-checkbox:disabled + label::before": {
+    ".ds-checkbox:disabled": {
       boxShadow: `inset 0 0 0 0.125rem ${theme("colors.gray.600")}`,
     },
-    ".ds-checkbox:disabled + label::after": {
+    ".ds-checkbox:disabled::after": {
       borderColor: theme("colors.gray.600"),
     },
-    ".ds-checkbox:disabled + label": {
+    ".ds-checkbox:disabled, .ds-checkbox:disabled + label": {
       cursor: "default",
     },
-    ".ds-checkbox.has-error + label::before": {
+    ".ds-checkbox.has-error": {
       boxShadow: `inset 0 0 0 0.125rem ${theme("colors.red.800")}`,
     },
     ".ds-checkbox-small + label": {
       paddingTop: "0.25rem",
-      paddingLeft: "2.5rem",
+      paddingLeft: "0.5rem",
       minHeight: "2rem",
     },
-    ".ds-checkbox-small + label::before": { width: "2rem", height: "2rem" },
-    ".ds-checkbox-small:checked + label::after": {
+    ".ds-checkbox-small": {
+      width: "2rem",
+      height: "2rem",
+    },
+    ".ds-checkbox-small:checked::after": {
       top: "1rem",
       left: "0.875rem",
+    },
+    ":has(> .ds-checkbox + label):has(> :nth-child(2):last-child)": {
+      display: "flex",
     },
   });
 };

--- a/src/components/radio.js
+++ b/src/components/radio.js
@@ -1,26 +1,35 @@
-const a11y = require("../utils/a11y");
-
 module.exports = function ({ addComponents, theme }) {
   addComponents({
-    ".ds-radio": a11y.srOnly,
-    ".ds-radio + label, .ds-radio + label::before, .ds-radio + label::after": {
+    ".ds-radio, .ds-radio + label, .ds-radio::after": {
       "--radio-ring-radius": "1.25rem",
       "--radio-ring-diameter": "calc(var(--radio-ring-radius) * 2)",
       "--radio-dot-radius": "0.75rem",
       "--radio-text-padding-left": "1rem",
       "--radio-text-padding-top": "0.4375rem",
     },
+    ".ds-radio": {
+      appearance: "none",
+      width: "var(--radio-ring-diameter)",
+      height: "var(--radio-ring-diameter)",
+      boxShadow: `inset 0 0 0 0.125rem ${theme("colors.blue.800")}`,
+      position: "relative",
+      outline: "none",
+      cursor: "pointer",
+      borderRadius: "50%",
+      float: "left",
+      flex: "none",
+    },
     ".ds-radio + label": {
       position: "relative",
-      display: "inline-block",
       paddingTop: "var(--radio-text-padding-top)",
-      paddingLeft:
-        "calc(var(--radio-ring-diameter) + var(--radio-text-padding-left))",
+      paddingLeft: "var(--radio-text-padding-left)",
       minHeight: "var(--radio-ring-diameter)",
       touchAction: "manipulation",
       cursor: "pointer",
+      verticalAlign: "top",
+      float: "left",
     },
-    ".ds-radio + label::before, .ds-radio + label::after": {
+    ".ds-radio::after": {
       content: '""',
       display: "block",
       position: "absolute",
@@ -28,18 +37,10 @@ module.exports = function ({ addComponents, theme }) {
       left: "0",
       transform: "translateY(-50%)",
     },
-    ".ds-radio + label::before": {
-      left: "0",
-      width: "var(--radio-ring-diameter)",
-      height: "var(--radio-ring-diameter)",
-      boxShadow: `inset 0 0 0 0.125rem ${theme("colors.blue.800")}`,
-      borderRadius: "50%",
+    ".ds-radio:focus, .ds-radio:focus-visible": {
+      boxShadow: `inset 0 0 0 0.25rem ${theme("colors.blue.800")}`,
     },
-    ".ds-radio:focus + label::before, .ds-radio:focus-visible + label::before":
-      {
-        boxShadow: `inset 0 0 0 0.25rem ${theme("colors.blue.800")}`,
-      },
-    ".ds-radio:checked + label::after": {
+    ".ds-radio:checked::after": {
       left: "calc(var(--radio-ring-radius) - var(--radio-dot-radius))",
       width: "0",
       height: "0",
@@ -47,35 +48,36 @@ module.exports = function ({ addComponents, theme }) {
       backgroundColor: theme("colors.blue.800"),
       borderRadius: "50%",
     },
-    ".ds-radio[disabled] + label": {
+    ".ds-radio[disabled], .ds-radio[disabled] + label": {
       cursor: "default",
     },
-    ".ds-radio[disabled] + label::before": {
+    ".ds-radio[disabled]": {
       boxShadow: `inset 0 0 0 0.125rem ${theme("colors.gray.600")}`,
     },
-    ".ds-radio[disabled] + label::after": {
+    ".ds-radio[disabled]::after": {
       borderColor: theme("colors.gray.600"),
       backgroundColor: theme("colors.gray.600"),
     },
-    ".ds-radio:not(:disabled):hover + label::before": {
+    ".ds-radio:not(:disabled):hover": {
       boxShadow: `inset 0 0 0 0.25rem ${theme("colors.blue.800")}`,
     },
-    ".ds-radio:not(:focus-visible):focus + label::before": {
+    ".ds-radio:not(:focus-visible):focus": {
       boxShadow: `inset 0 0 0 0.125rem ${theme("colors.blue.800")}`,
     },
-    ".ds-radio-small + label, .ds-radio-small + label::before, .ds-radio-small + label::after":
-      {
-        "--radio-ring-radius": "1rem",
-        "--radio-dot-radius": "0.5rem",
-        "--radio-text-padding-left": "0.75rem",
-        "--radio-text-padding-top": "0.3125rem",
-      },
-    ".ds-radio-mini + label, .ds-radio-mini + label::before, .ds-radio-mini + label::after":
-      {
-        "--radio-ring-radius": "0.75rem",
-        "--radio-dot-radius": "0.3125rem",
-        "--radio-text-padding-left": "0.625rem",
-        "--radio-text-padding-top": "0.0625rem",
-      },
+    ".ds-radio-small, .ds-radio-small + label, .ds-radio-small::after": {
+      "--radio-ring-radius": "1rem",
+      "--radio-dot-radius": "0.5rem",
+      "--radio-text-padding-left": "0.75rem",
+      "--radio-text-padding-top": "0.3125rem",
+    },
+    " .ds-radio-mini, .ds-radio-mini + label, .ds-radio-mini::after": {
+      "--radio-ring-radius": "0.75rem",
+      "--radio-dot-radius": "0.3125rem",
+      "--radio-text-padding-left": "0.625rem",
+      "--radio-text-padding-top": "0.0625rem",
+    },
+    ":has(> .ds-radio + label):has(> :nth-child(2):last-child)": {
+      display: "flex",
+    },
   });
 };


### PR DESCRIPTION
Hello, as discussed I updated the checkbox to have its styling on the `input` element, rather than the label's pseudo elements. It 95% looks and works exactly the same as before, however there is one case I didn't find a great solution for: 

When the label spans multiple lines, it wraps below the checkbox, which doesn't look great. I now solved this by detecting if an element contains exactly one checkbox followed by a label. The element will then receive a flex layout which fixes the wrapping.

Some thoughts:

- This uses the `:has` selector which Firefox currently only supports behind a feature flag ([full support should be available soon though](https://connect.mozilla.org/t5/ideas/when-is-has-css-selector-going-to-be-fully-implemented-in/idi-p/23794/page/2#comments)), so if this is the solution we're going for we'll need a workaround for the time being.

- I tried to keep the markup exactly like it was without needing any additional classes, but maybe it's acceptable to either add a `.ds-checkbox-layout` (or similarly named) class or a note about having to add a wrapping container with a `flex` Tailwind class to make it more explicit?

- Generally I think having to add a little bit of supporting layout for multiline labels is fine, most checkboxes will likely not need it, and for those that do it's not a big hassle.

- The commit has a note about a breaking change as required by conventional commits, but this would push Angie to version 1, which I'm not sure we want. Are breaking changes in minor versions acceptable until we reach 1.0?