### PR TITLE
Update input placeholders

### DIFF
--- a/docs/pages/components/input.njk
+++ b/docs/pages/components/input.njk
@@ -33,6 +33,16 @@ layout: layouts/sidebar.njk
   </div>
 
   <div>
+    <label for="i5">Lorem ipsum (with placeholder and error)</label>
+    <input
+      type="text"
+      id="i5"
+      placeholder="Platzhalter"
+      class="ds-input has-error"
+    />
+  </div>
+
+  <div>
     <label for="im">Lorem ipsum (medium)</label>
     <input type="text" value="Text" id="im" class="ds-input ds-input-medium" />
   </div>

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -37,24 +37,20 @@ module.exports = function ({ addComponents, theme }) {
       boxShadow: `inset 0 0 0 4px ${theme("colors.blue.800")}`,
     },
     "::-webkit-input-placeholder": {
-      fontFamily: "BundesSerifWeb, serif",
-      fontStyle: "italic",
-      color: theme("colors.gray.800"),
+      fontFamily: "BundesSansWeb, sans-serif",
+      color: `${theme("colors.gray.800")} !important`,
     },
     "::-moz-placeholder": {
-      fontFamily: "BundesSerifWeb, serif",
-      fontStyle: "italic",
-      color: theme("colors.gray.800"),
+      fontFamily: "BundesSansWeb, sans-serif",
+      color: `${theme("colors.gray.800")} !important`,
     },
     ":-ms-input-placeholder": {
-      fontFamily: "BundesSerifWeb, serif",
-      fontStyle: "italic",
-      color: theme("colors.gray.800"),
+      fontFamily: "BundesSansWeb, sans-serif",
+      color: `${theme("colors.gray.800")} !important`,
     },
     ":-moz-placeholder": {
-      fontFamily: "BundesSerifWeb, serif",
-      fontStyle: "italic",
-      color: theme("colors.gray.800"),
+      fontFamily: "BundesSansWeb, sans-serif",
+      color: `${theme("colors.gray.800")} !important`,
     },
     ".ds-input-medium": {
       height: "3rem",


### PR DESCRIPTION
This introduces changes to the placeholders used in input fields. We want to enhance readability and accessibility—especially for combinations with errors.

**Changes Made**
- non-serif font
- not italic
- darker font (was overwritten by tailwind defaults 🪲)

| previously  | proposed change |
| ------------- | ------------- |
| <img width="514" alt="previously" src="https://github.com/digitalservicebund/angie/assets/2386669/d64d07dd-b5ff-4b6e-bf8a-cf30d85b9793"> | <img width="517" alt="image" src="https://github.com/digitalservicebund/angie/assets/2386669/3a412908-02b0-4114-8b4a-8aa5a409d33a"> |
| <img width="517" alt="previously2" src="https://github.com/digitalservicebund/angie/assets/2386669/b1f69e4d-2ce6-4195-9767-8f5e86325b74">  | <img width="517" alt="updated2" src="https://github.com/digitalservicebund/angie/assets/2386669/45166ec6-b3fd-4a85-9af0-6bee74722927"> |
