### PR TITLE
fix(radio): Make background transparent for old safari versions

### DIFF
--- a/src/components/radio.js
+++ b/src/components/radio.js
@@ -18,6 +18,7 @@ module.exports = function ({ addComponents, theme }) {
       borderRadius: "50%",
       float: "left",
       flex: "none",
+      background: "transparent" /* for old Safari */,
     },
     ".ds-radio + label": {
       position: "relative",


### PR DESCRIPTION
We have this in [A2J](https://github.com/digitalservicebund/a2j-rechtsantragstelle/blob/9b02a68fc289f2476f3b43d14550cc3b3611b96b/app/styles.css#L46) for quite a while now (Dec, 2023).
It is originally by @joschka and I honestly didn't find the concrete reasoning behind this to include it here.
So - could you review?