### PR TITLE
fix(textarea): Apply input error style to textarea

### DIFF
--- a/src/components/input.js
+++ b/src/components/input.js
@@ -31,7 +31,7 @@ module.exports = function ({ addComponents, theme }) {
       cursor: "not-allowed",
       backgroundColor: theme("colors.white"),
     },
-    ".ds-input.has-error": {
+    ".ds-input.has-error, .ds-textarea.has-error": {
       boxShadow: `inset 0 0 0 2px ${theme("colors.red.800")}`,
       backgroundColor: theme("colors.red.200"),
     },


### PR DESCRIPTION
Another thing that we previously fixed in [A2J](https://github.com/digitalservicebund/a2j-rechtsantragstelle/blob/9b02a68fc289f2476f3b43d14550cc3b3611b96b/app/styles.css#L40) - the error state was not displayed correctly for textfields.

This is the Before:
<img width="866" alt="Bildschirm­foto 2024-07-11 um 15 37 15" src="https://github.com/digitalservicebund/angie/assets/9320199/9fe7a7ee-bb7e-4a62-a879-9d5314971231">
And the After:
<img width="868" alt="Bildschirm­foto 2024-07-11 um 15 37 27" src="https://github.com/digitalservicebund/angie/assets/9320199/82379b6c-0d3d-4f58-a73e-7b96f3be41cc">
